### PR TITLE
Integrate ZBL short-range repulsion into Nequix

### DIFF
--- a/nequix/train.py
+++ b/nequix/train.py
@@ -227,7 +227,7 @@ def train(config_path: str):
     key = jax.random.key(0)
     model = Nequix(
         key,
-        n_species=len(config["atomic_numbers"]),
+        atomic_numbers=config["atomic_numbers"],
         hidden_irreps=config["hidden_irreps"],
         lmax=config["lmax"],
         cutoff=config["cutoff"],

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -42,7 +42,7 @@ def test_model():
     # small model for testing
     model = Nequix(
         key,
-        n_species=2,
+        atomic_numbers=[1, 6],
         lmax=1,
         hidden_irreps="8x0e+8x1o",
         n_layers=2,
@@ -110,7 +110,7 @@ def test_model_save_load():
     atom_energies = [config["atom_energies"][n] for n in config["atomic_numbers"]]
     model = Nequix(
         key,
-        n_species=len(config["atomic_numbers"]),
+        atomic_numbers=config["atomic_numbers"],
         cutoff=config["cutoff"],
         lmax=config["lmax"],
         hidden_irreps=config["hidden_irreps"],
@@ -155,7 +155,7 @@ def test_weight_decay_mask():
     key = jax.random.key(0)
     model = Nequix(
         key,
-        n_species=2,
+        atomic_numbers=[1, 6],
         lmax=1,
         hidden_irreps="8x0e+8x1o",
         n_layers=2,


### PR DESCRIPTION
## Summary
- incorporate covalent radii table and ZBL pairwise repulsion energy
- extend `Nequix` to track atomic numbers and covalent radii
- add ZBL energy term during total energy computation
- update tests and training code for new initialization signature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jax')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement hatchling)*

------
https://chatgpt.com/codex/tasks/task_e_68c66b4c85488331b1f71f8f78b8a21d